### PR TITLE
Actually, it's neither encrypted nor signed.

### DIFF
--- a/source/12-sessions/02-sinatra_sessions.md
+++ b/source/12-sessions/02-sinatra_sessions.md
@@ -46,7 +46,7 @@ Ok, cool.
 The `session` looks like a simple Ruby hash, but if we store something to it
 then Sinatra will set a cookie for us. It does so by sending a `Set-Cookie`
 header along the reponse. This header will have a long, messy looking,
-encrypted string as a value.
+encoded string as a value.
 
 In my browser it looks like this:
 
@@ -90,7 +90,7 @@ How does this work?
 In our `post` route we store the message to the session hash. This is
 something Sinatra provides to us as developers. When we enable this
 feature Sinatra will, after every request, store this hash to a cookie
-with the name `rack.session`, in the encrypted form that you saw above.
+with the name `rack.session`, in the encoded form that you saw above.
 
 We say the hash is being <a href="http://en.wikipedia.org/wiki/Serialization">serialized</a>,
 which is a fancy way of saying it is turned into some kind of format that


### PR DESCRIPTION
Without `set :session_secret`, it's just URL, Base64, and Marshal encoded.

```ruby
require 'uri'
require 'base64'
cookie = 'BAh7CUkiD3Nlc3Npb25faWQGOgZFVEkiRWI4OTdhMDJlNDBkMDFlNjcxNWUw%0AZGI1ZWU5MzQ0YTQyMjAzYjFiZTE2YzYxNzgwMWQxYjI3NzhiOWNhYTQ4YzUG%0AOwBGSSIJY3NyZgY7AEZJIiU2ZjdjN2Y0ZmM0MTdmMGJkNjBkNmY5MmQ1NDEx%0ANGQ4ZgY7AEZJIg10cmFja2luZwY7AEZ7B0kiFEhUVFBfVVNFUl9BR0VOVAY7%0AAFRJIi03NGNlNDIxYTczNjMwZDY3MWViNTlkYzIzN2YyN2M5NGU3ZWU4NTRm%0ABjsARkkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsAVEkiLTA3NjBhNDRjMzU0%0AODIxMzJjZjIyNDQyYTBkODhjMDhiYjg1NTYyNTAGOwBGSSIIZm9vBjsARkki%0ACGJhcgY7AFQ%3D%0A'
p Marshal.load(Base64.decode64(URI.decode_www_form_component(cookie)))
# {
#   'session_id' => 'b897a02e40d01e6715e0db5ee9344a42203b1be16c617801d1b2778b9caa48c5',
#   'csrf' => '6f7c7f4fc417f0bd60d6f92d54114d8f',
#   'tracking' => {
#     'HTTP_USER_AGENT' => '74ce421a73630d671eb59dc237f27c94e7ee854f',
#     'HTTP_ACCEPT_LANGUAGE' => '0760a44c35482132cf22442a0d88c08bb8556250'
#   },
#   'foo' => 'bar'
# }
```