### PR TITLE
Update params.inspect example

### DIFF
--- a/source/09-sinatra/05-params.md
+++ b/source/09-sinatra/05-params.md
@@ -60,12 +60,14 @@ If you restart your application, and reload the page in your browser, then it
 should display something like this:
 
 ```
-{"splat"=>[], "captures"=>["monstas"], "name"=>"monstas"}
+{"name"=>"monstas"}
 ```
 
 So this confirms that `params` is a hash, and the key `"name"` has the value
-`"monstas"` set.  `splat` and `captures` are for building more complicated
-routes, and we can ignore these for now.
+`"monstas"` set. In fact, it isn't _really_ a hash, just something very similar
+to a hash called `Sinatra::IndifferentHash` which is exacly like a hash, with a
+small trick applied so that we can access the keys indistinctly as strings or
+symbols. That's why we could use `params[:name]` in the previous example.
 
 This is pretty cool.
 


### PR DESCRIPTION
Apparently, Sinatra no longer includes this extra `capures` and `splat` keys unless the route is actually using a `*` segment or a regular expression (I have Sinatra 2.0.5 in my machine, I think [this](https://github.com/sinatra/sinatra/pull/1390/files) is the relevant change for `captures`, while I can't find the one for `splat`, which is probably in Mustermann).

Since we are not introducing these features in this chapter, I removed those keys from the example to avoid confusion.

My test app and its output:

```ruby
require 'sinatra'

get '/param/:name' do
  params.inspect
end

get %r{/regexp/(\d+)} do
  params.inspect
end

get '/splat/*/*' do
  params.inspect
end
```

```
sergio@riga ~> curl http://localhost:4567/param/sergio
{"name"=>"sergio"}
sergio@riga ~> curl http://localhost:4567/regexp/123
{"captures"=>["123"]}
sergio@riga ~> curl http://localhost:4567/splat/hello/world
{"splat"=>["hello", "world"]}
```

Versions of things:

* bundler (1.16.3)
* mustermann (1.0.3)
* rack (2.0.6)
* rack-protection (2.0.5)
* sinatra (2.0.5)
* tilt (2.0.9)